### PR TITLE
fix: Update References

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   main:
     name: Publish to GitHub pages
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:

--- a/src/boilerplate/considerations.md
+++ b/src/boilerplate/considerations.md
@@ -8,7 +8,7 @@ This section details security and privacy considerations.
 
 Some of the normative references within this specification point to documents with a Living Standard or Draft status, meaning their contents can still change over time. It is advised to monitor these documents, as such changes might have implications.
 
-Since [PROTOCOL] defines representation and semantics for the use of [SUPER] to transmit notifications from Solid resources, it follows that the [PROTOCOL] inherits security and privacy considerations of both the [SUPER] and the Solid Protocol. Considerations relevant to the use of [SUPER] for transmitting notifications are discussed in [[!PREP]] [[PREP#name-considerations|§ 11 Considerations]], and considerations relevant to Solid Protocol are discussed in  [[!SOLID]] [[SOLID#considerations|§ 10 Considerations]].
+Since [PROTOCOL] defines representation and semantics for the use of [SUPER] to transmit notifications from Solid resources, it follows that the [PROTOCOL] inherits security and privacy considerations of both the [SUPER] and the Solid Protocol. Considerations relevant to the use of [SUPER] for transmitting notifications are discussed in [[!PREP]] [[PREP#name-considerations|§ 11 Considerations]], and considerations relevant to Solid Protocol are discussed in  [[!SOLID-PROTOCOL]] [[SOLID-PROTOCOL#considerations|§ 10 Considerations]].
 
 ## Security Considerations ## {#security-considerations}
 

--- a/src/index.bs
+++ b/src/index.bs
@@ -144,36 +144,30 @@ Status Text:
 
 <pre class="biblio">
 {
-  "SOLID": {
-    "note": "Work in Progress",
+  "SOLID-PROTOCOL": {
     "authors": [
       "Sarven Capadisli, Ed.",
       "Tim Berners-Lee, Ed.",
-      "Ruben Verborgh, Ed.",
-      "Kjetil Kjernsmo Ed."
+      "Kjetil Kjernsmo, Ed."
     ],
     "href": "https://solidproject.org/TR/protocol",
-    "edDraft": "https://solidproject.org/ED/protocol",
     "title": "Solid Protocol",
-    "status": "Editor's Draft",
+    "status": "Draft Community Group Report",
     "publisher": "Solid Community Group"
   },
   "SOLID-NOTIFICATIONS": {
-    "note": "Work in Progress",
     "authors": [
+      "Sarven Capadisli, Ed.",
       "Aaron Coburn",
-      "Sarven Capadisli",
       "elf Pavlik",
       "Rahul Gupta"
     ],
     "href": "https://solidproject.org/TR/notifications-protocol",
-    "edDraft": "https://solid.github.io/notifications/protocol",
     "title": "Solid Notifications Protocol",
-    "status": "Editor's Draft",
+    "status": "Draft Community Group Report",
     "publisher": "Solid Community Group"
   },
   "PREP": {
-    "note": "Work in Progress",
     "authors": [
       "Rahul Gupta"
     ],

--- a/src/sections/conformance.md
+++ b/src/sections/conformance.md
@@ -5,10 +5,10 @@ The [PROTOCOL] identifies the following Classes of Products for conforming imple
 <dl>
 
   : <dfn>Solid Server</dfn>
-  :: A *Solid server* that builds on a [[Solid#server|server]] [[!SOLID]] and [[PREP#resource-server|resource server]] [[!PREP]] by defining the behaviour of resources.
+  :: A *Solid server* that builds on a [[SOLID-PROTOCOL#Server|server]] [[!SOLID-PROTOCOL]] and [[PREP#resource-server|resource server]] [[!PREP]] by defining the behaviour of resources.
 
   : <dfn>Solid Client</dfn>
-  :: A *Solid client* that builds on a [[Solid#client|client]] [[!SOLID]] and [[PREP#application-client|application client]] [[!PREP]].
+  :: A *Solid client* that builds on a [[SOLID-PROTOCOL#Client|client]] [[!SOLID-PROTOCOL]] and [[PREP#application-client|application client]] [[!PREP]].
 
 </dl>
 

--- a/src/sections/introduction.md
+++ b/src/sections/introduction.md
@@ -2,7 +2,7 @@
 
 *This section is non-normative.*
 
-Solid [[SOLID]] uses linked data to interconnect data across decentralized data stores called PODS. [SUPER] [[PREP]] allows servers to transmit notifications over HTTP that can be customized for any given resource. This specification defines representation and semantics for [PREP] notifications sent from linked data resources hosted on Solid PODS.
+Solid [[SOLID-PROTOCOL]] uses linked data to interconnect data across decentralized data stores called PODS. [SUPER] [[PREP]] allows servers to transmit notifications over HTTP that can be customized for any given resource. This specification defines representation and semantics for [PREP] notifications sent from linked data resources hosted on Solid PODS.
 
 ## Audience ## {#intended-audience}
 

--- a/src/sections/triggers.md
+++ b/src/sections/triggers.md
@@ -7,7 +7,7 @@ A [=Solid server=] MUST NOT transmit a [PREP] notification before the resource h
 <div class="advisement">
   <div class="marker">Implementation Guidance</div>
 
-  The Solid Protocol [[SOLID]] requires an LDP container's state is modified when certain HTTP events occur on a contained resource. Thus, an HTTP event on a resource can trigger a [=Solid server=] to transmit a [PREP] notification on that resource or its container or both.
+  The Solid Protocol [[SOLID-PROTOCOL]] requires an LDP container's state is modified when certain HTTP events occur on a contained resource. Thus, an HTTP event on a resource can trigger a [=Solid server=] to transmit a [PREP] notification on that resource or its container or both.
 
   It follows that a [=Solid server=] ought to send [PREP] notification(s) on an resource and/or its container, when a request with one of the following [[RFC9110#methods|HTTP methods]] generates a response with any of the following [[RFC9110#status.codes|HTTP status codes]]:
 


### PR DESCRIPTION
Updates references to Solid protocol and Solid Notifications protocol:
+ update authors list,
+ change document status to Draft CG Report,
+ remove WIP note,
+ remove ED links.

Changed references from SOLID to SOLID-PROTOCOL throughout the document.