### PR TITLE
fix: `id` and `state` in Data Model

### DIFF
--- a/src/sections/conformance.md
+++ b/src/sections/conformance.md
@@ -36,10 +36,13 @@ This document uses the following RDF vocabularies and corresponding namespace pr
       <th> Description
   <tbody>
     <tr>
+      <td> <code>rdf
+      <td> <samp>https://www.w3.org/1999/02/22-rdf-syntax-ns#
+      <td> [[!RDF-SCHEMA]]
+    <tr>
       <td> <code>xs
       <td> <samp>http://www.w3.org/2001/XMLSchema#
       <td> [[!XMLSCHEMA11-1]]
-  <tbody>
     <tr>
       <td> <code>as
       <td> <samp>https://www.w3.org/ns/activitystreams#

--- a/src/sections/conformance.md
+++ b/src/sections/conformance.md
@@ -36,10 +36,6 @@ This document uses the following RDF vocabularies and corresponding namespace pr
       <th> Description
   <tbody>
     <tr>
-      <td> <code>rdf
-      <td> <samp>https://www.w3.org/1999/02/22-rdf-syntax-ns#
-      <td> [[!RDF-SCHEMA]]
-    <tr>
       <td> <code>xs
       <td> <samp>http://www.w3.org/2001/XMLSchema#
       <td> [[!XMLSCHEMA11-1]]

--- a/src/sections/data-model.md
+++ b/src/sections/data-model.md
@@ -8,8 +8,8 @@ A [PREP] notification from an LDP Resource on a [=Solid server=] MUST have the f
 
 <dl>
 
-  <dt id="notification-property-id"><code>*id* &lt;rdfs:subject></code>
-  <dd> a unique identifier for a notification.
+  <dt id="notification-property-id"><code>*id*</code>
+  <dd> an absolute IRI (Internationalized Resource Identifier) that uniquely identifies the notification.
 
   <dt id="notification-property-type"><code>*as:type* &lt;as:Activity></code>
   <dd> the [[ACTIVITYSTREAMS-VOCABULARY#activity-types|type of activity]] that triggered the notification.

--- a/src/sections/data-model.md
+++ b/src/sections/data-model.md
@@ -9,7 +9,7 @@ A [PREP] notification from an LDP Resource on a [=Solid server=] MUST have the f
 <dl>
 
   <dt id="notification-property-id"><code>*id* &lt;rdfs:subject></code>
-  <dd> an unique identifier for a notification.
+  <dd> a unique identifier for a notification.
 
   <dt id="notification-property-type"><code>*as:type* &lt;as:Activity></code>
   <dd> the [[ACTIVITYSTREAMS-VOCABULARY#activity-types|type of activity]] that triggered the notification.

--- a/src/sections/data-model.md
+++ b/src/sections/data-model.md
@@ -8,13 +8,13 @@ A [PREP] notification from an LDP Resource on a [=Solid server=] MUST have the f
 
 <dl>
 
-  <dt id="notification-property-id"><code>*id* &lt;xs:string></code>
-  <dd> an opaque identifier for the notification. Can be used to set `Last-Event-ID` in a subsequent [PREP] notifications request.
+  <dt id="notification-property-id"><code>*id* &lt;rdfs:subject></code>
+  <dd> an unique identifier for a notification.
 
-  <dt id="notification-property-type"><code>*type* &lt;as:Activity></code>
+  <dt id="notification-property-type"><code>*as:type* &lt;as:Activity></code>
   <dd> the [[ACTIVITYSTREAMS-VOCABULARY#activity-types|type of activity]] that triggered the notification.
 
-  <dt id="notification-property-published"><code>*published* &lt;xs:dateTime></code>
+  <dt id="notification-property-published"><code>*as:published* &lt;xs:dateTime></code>
   <dd> the date and time of the notification.
 
 </dl>
@@ -23,8 +23,8 @@ A [PREP] notification from an LDP Resource on a [=Solid server=] SHOULD have the
 
 <dl>
 
-  <dt id="notification-property-state"><code>*state* &lt;xs:string></code>
-  <dd> an opaque identifier for the last known state of the resource.
+  <dt id="notification-property-state"><code>*notify:state* &lt;xs:string></code>
+  <dd> an opaque identifier for the last known state of the resource. Can be used to set `Last-Event-ID` in a subsequent [PREP] notifications request.
 
 </dl>
 


### PR DESCRIPTION
+ `id` is a IRI or bnode (not string).
+ `notify:state` (not `id`) can be used to set `Last-Event-ID`.
+ Add prefixes to properties in Data Model.

Fixes #11.