### PR TITLE
feat: Add Examples

### DIFF
--- a/src/examples/request.http
+++ b/src/examples/request.http
@@ -1,0 +1,4 @@
+GET /John_Doe HTTP/1.1
+Host: example.com
+Accept-Encoding: application/ld+json
+Accept-Events: "prep"; accept=application/ld+json

--- a/src/examples/response.http
+++ b/src/examples/response.http
@@ -1,0 +1,48 @@
+HTTP/1.1 200 OK
+Accept: text/turtle, application/ld+json
+Accept-Events: "prep";accept=("message/rfc822" "application/ld+json")
+Events: protocol="prep", status=200, expires="Thu, 07 Nov 2024 15:13:48 GMT"
+Content-Type: multipart/mixed; boundary="main-boundary"
+
+--main-boundary
+Content-Type: application/ld+json
+
+{
+  "@context": "https://json-ld.org/contexts/person.jsonld",
+  "@id": "http://dbpedia.org/resource/John_Doe",
+  "name": "John Doe"
+}
+
+--main-boundary
+Content-Type: multipart/digest; boundary="notification-boundary"
+
+--notification-boundary
+Content-Type: application/ld+json
+
+{
+  "published": "2024-11-10T11:12:13Z",
+  "type": "Update",
+  "object": "https://example.com/John_Doe",
+  "state": "ABC123"
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://www.w3.org/ns/solid/notification/v1"
+  ]
+}
+
+--notification-boundary
+Content-Type: application/ld+json
+
+{
+  "published": "2024-11-10T14:15:16Z",
+  "type": "Delete",
+  "object": "https://example.com/John_Doe",
+  "state": "DEF456"
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://www.w3.org/ns/solid/notification/v1"
+  ]
+}
+
+--notification-boundary--
+--main-boundary--

--- a/src/sections/request.md
+++ b/src/sections/request.md
@@ -1,3 +1,10 @@
 # Request # {#request}
 
-A [=Solid server=] implementing [SUPER] on an LDP Resource MUST accept [[PREP#request|requests]] [[!PREP]] when the `accept` [[PREP#event-field|event-field]] associated with the `PREP` list item in the <code>[[PREP#accept-events|Accept-Events]]</code> header field indicates a preferred media type of `application/ld+json` [[!JSON-LD11]].
+A [=Solid server=] implementing [SUPER] on an LDP Resource MUST accept [[PREP#request|requests]] [[!PREP]] when the `accept` [[PREP#event-field|event-field]] associated with the `"prep"` list item in the <code>[[PREP#accept-events|Accept-Events]]</code> header field indicates a preferred media type of `application/ld+json` [[!JSON-LD11]].
+
+<div class="example">
+  <span class="marker">Request for Solid-PREP Notifications</span>
+  <pre class="include-code">
+    path: examples/request.http
+  </pre>
+</div>

--- a/src/sections/response.md
+++ b/src/sections/response.md
@@ -1,3 +1,10 @@
-# Format # {#format}
+# Response # {#Response}
 
 A [=Solid server=] implementing [SUPER] on an LDP Resource MUST be able to transmit [PREP] notifications using the `application/ld+json` [[!JSON-LD11]] media type. It MAY also support other media types to transmit [PREP] notifications.
+
+<div class="example">
+  <span class="marker">Response with Solid-PREP Notifications</span>
+  <pre class="include-code">
+    path: examples/response.http
+  </pre>
+</div>


### PR DESCRIPTION
* Added examples for request and response.
* Renamed Format section to Response.
* Fixed list item triggering PREP notifications in `Accept-Events` header field is `"prep"`.

Fixes #12.