### PR TITLE
feat!: Generalize Resources

### DIFF
--- a/src/index.bs
+++ b/src/index.bs
@@ -20,7 +20,7 @@ Editor: Rahul Gupta, https://cxres.pages.dev/profile/#i
 !Authors: <a href="https://cxres.pages.dev/profile/#i">Rahul Gupta</a>
 !Authors: <a href="https://elf-pavlik.hackers4peace.net">elf Pavlik</a>
 Abstract:
-  Solid-PREP defines representation and semantics for notifications sent from LDP Resources hosted on Solid servers using the Per Resource Events Protocol.
+  Solid-PREP defines representation and semantics for linked data based notifications sent from resources hosted on Solid servers using the Per Resource Events Protocol.
 
 Status Text:
   This section describes the status of this document at the time of its publication.

--- a/src/sections/activity-mapping.md
+++ b/src/sections/activity-mapping.md
@@ -1,17 +1,17 @@
 # Activity Mapping # {#activity-mapping}
 
-A [=Solid server=] sending a [PREP] notification as a result of some activity on an LDP Resource MUST set the [type](#notification-property-type) property as the [[ACTIVITYSTREAMS-VOCABULARY#activity-types|type of activity]] that triggered the notification as specified by the Activity Streams vocabulary [[ACTIVITYSTREAMS-VOCABULARY]].
+A [=Solid server=] sending a [PROTOCOL] notification as a result of some activity on a resource MUST set the [type](#notification-property-type) property as the [[ACTIVITYSTREAMS-VOCABULARY#activity-types|type of activity]] that triggered the notification as specified by the Activity Streams vocabulary [[ACTIVITYSTREAMS-VOCABULARY]].
 
 
 <div class="advisement">
   <div class="marker">Implementation Guidance</div>
 
-  When an LDP resource is modified by virtue of an HTTP request, the activity type ought to be set as follows:
+  When a resource is modified by virtue of an HTTP request, the activity type ought to be set as follows:
 
   1. When the [PREP] notification is triggered by a request on the resource with one of the following [[RFC9110#methods|HTTP methods]]:
 
     <table class="numbered">
-      <caption> Activity Mapping for LDP Resources
+      <caption> Activity Mapping for Resources
       <thead>
         <tr>
           <th> Request Method

--- a/src/sections/data-model.md
+++ b/src/sections/data-model.md
@@ -4,7 +4,7 @@ The core notification data is expressed with the Activity Streams [[ACTIVITYSTRE
 
 ## Properties ## {#notification-properties}
 
-A [PREP] notification from an LDP Resource on a [=Solid server=] MUST have the following properties:
+A [PROTOCOL] notification from an resource on a [=Solid server=] MUST have the following properties:
 
 <dl>
 
@@ -19,7 +19,7 @@ A [PREP] notification from an LDP Resource on a [=Solid server=] MUST have the f
 
 </dl>
 
-A [PREP] notification from an LDP Resource on a [=Solid server=] SHOULD have the following properties:
+A [PROTOCOL] notification from an resource on a [=Solid server=] SHOULD have the following properties:
 
 <dl>
 

--- a/src/sections/introduction.md
+++ b/src/sections/introduction.md
@@ -2,7 +2,7 @@
 
 *This section is non-normative.*
 
-Solid [[SOLID-PROTOCOL]] uses linked data to interconnect data across decentralized data stores. [SUPER] [[PREP]] allows servers to transmit notifications over HTTP that can be customized for any given resource. This specification defines representation and semantics for [PREP] notifications sent from linked data resources hosted on Solid servers.
+Solid [[SOLID-PROTOCOL]] uses linked data to interconnect data across decentralized data stores. [SUPER] [[PREP]] allows servers to transmit notifications over HTTP that can be customized for any given resource. This specification defines representation and semantics for linked data [PREP] based notifications sent from resources hosted on Solid servers.
 
 ## Audience ## {#intended-audience}
 
@@ -10,5 +10,5 @@ Solid [[SOLID-PROTOCOL]] uses linked data to interconnect data across decentrali
 
 This specification is for:
 
-+ [Server developers](http://data.europa.eu/esco/occupation/a7c1d23d-aeca-4bee-9a08-5993ed98b135) who wish to enable clients to listen for updates to LDP Resources on Solid servers.
-+ [Application developers](http://data.europa.eu/esco/occupation/c40a2919-48a9-40ea-b506-1f34f693496d) who wish to implement a client to listen for updates to LDP Resources on Solid servers.
++ [Server developers](http://data.europa.eu/esco/occupation/a7c1d23d-aeca-4bee-9a08-5993ed98b135) who wish to enable clients to listen for updates to resources on Solid servers.
++ [Application developers](http://data.europa.eu/esco/occupation/c40a2919-48a9-40ea-b506-1f34f693496d) who wish to implement a client to listen for updates to resources on Solid servers.

--- a/src/sections/request.md
+++ b/src/sections/request.md
@@ -1,6 +1,6 @@
 # Request # {#request}
 
-A [=Solid server=] implementing [SUPER] on an LDP Resource MUST accept [[PREP#request|requests]] [[!PREP]] when the `accept` [[PREP#event-field|event-field]] associated with the `"prep"` list item in the <code>[[PREP#accept-events|Accept-Events]]</code> header field indicates a preferred media type of `application/ld+json` [[!JSON-LD11]].
+A [=Solid server=] implementing [PROTOCOL] on an resource MUST accept [[PREP#request|requests]] [[!PREP]] when the `accept` [[PREP#event-field|event-field]] associated with the `"prep"` list item in the <code>[[PREP#accept-events|Accept-Events]]</code> header field indicates a preferred media type of `application/ld+json` [[!JSON-LD11]].
 
 <div class="example">
   <span class="marker">Request for Solid-PREP Notifications</span>

--- a/src/sections/response.md
+++ b/src/sections/response.md
@@ -1,6 +1,6 @@
 # Response # {#Response}
 
-A [=Solid server=] implementing [SUPER] on an LDP Resource MUST be able to transmit [PREP] notifications using the `application/ld+json` [[!JSON-LD11]] media type. It MAY also support other media types to transmit [PREP] notifications.
+A [=Solid server=] implementing [PROTOCOL] on an resource MUST be able to transmit [PREP] notifications using the `application/ld+json` [[!JSON-LD11]] media type. It MAY also support other media types to transmit [PREP] notifications.
 
 <div class="example">
   <span class="marker">Response with Solid-PREP Notifications</span>

--- a/src/sections/triggers.md
+++ b/src/sections/triggers.md
@@ -1,6 +1,6 @@
 # Triggers # {#triggers}
 
-A [=Solid server=] implementing the [SUPER] on an LDP Resource SHOULD send a [PREP] notification when the state of the said resource is modified.
+A [=Solid server=] implementing the [PROTOCOL] on a resource SHOULD send a [PREP] notification when the state of the said resource is modified.
 
 A [=Solid server=] MUST NOT transmit a [PREP] notification before the resource has been modified and a confirmation (if necessary) has been sent to (but might not have been received by) the agent that initiated the resource modification.
 


### PR DESCRIPTION
Solid-PREP notifications need not be specific to LDP Resources but can be sent from any resource.